### PR TITLE
Refactor: Added Downloader type 

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -47,7 +47,13 @@ func download() {
   storageChannel := make(chan *gmailservice.Message, BufferSize)
   wg.Add(1)
   go reader(s, storageChannel, &wg)
-  messages, err := gmailservice.Download(gsvc, lastDate, max, pageToken, inboxUrl)
+  options := gmailservice.Options{
+    LastDate: lastDate,
+    Limit: max,
+    InboxUrl: inboxUrl,
+  }
+  d := gmailservice.New(gsvc, options, 200)
+  messages, err := gmailservice.Download(d)
 
   log.Print("Done downloading: ", len(messages))
   if err != nil {

--- a/gmailservice/gmailservice_test.go
+++ b/gmailservice/gmailservice_test.go
@@ -2,13 +2,13 @@ package gmailservice
 
 import (
   "encoding/json"
-  "google.golang.org/api/gmail/v1"
-  "testing"
   "io/ioutil"
-  // "encoding/json"
   "log"
   "os"
   "strings"
+  "testing"
+
+  "google.golang.org/api/gmail/v1"
 )
 
 var expectedBody = "How are you doing? Some special characters: <>?$/:-)"
@@ -32,22 +32,6 @@ func JsonToGmail(jsonByteArray []byte) (gmail.Message, error) {
     return data, err
   }
   return data, nil
-}
-
-func TestDownload(t *testing.T) {
-  t.Skip()
-}
-
-func TestGetIndexOfMessages(t *testing.T) {
-  t.Skip()
-}
-
-func TestDownloadFullMessages(t *testing.T) {
-  t.Skip()
-}
-
-func TestExtractHeader(t *testing.T) {
-  t.Skip()
 }
 
 func TestBodyText(t *testing.T) {


### PR DESCRIPTION
- Reduce the number of arguments being passed to functions
- Allows us to stub out network functions for unit testing
- Using a channel to limit the number of simultaneous connections instead of sync.WaitGroup. Inspired by [Limiting Concurrency in Go](http://jmoiron.net/blog/limiting-concurrency-in-go/)

