### PR TITLE
Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,16 @@ account, can pass in a modified url. For example:
 
 ```bash
 go build
-./calliope download -l 1000 -d "2018/01/01" -u "https://mail.google.com/mail/#inbox/u/2/"
+./calliope download -l 1000 -d "2018/01/01" -u "https://mail.google.com/mail/u/2"
 ```
 
 or
 
 ```bash
-go run main.go download -l 1000 -d "2018/01/01" -u "https://mail.google.com/mail/#inbox/u/2/"
+go run main.go download -l 1000 -d "2018/01/01" -u "https://mail.google.com/mail/u/2/"
 ```
 
-will link to the 3rd logged in account.
+will link to the 3rd logged in account. See also [Debugging](#debugging), below.
 
 Initial output:
 ```
@@ -176,6 +176,18 @@ Sending Message ID: 1674c3c1f389215b
 2018/11/25 11:50:15 Indexed data id 1674c3c1f389215b to index mail, type document
 ```
 
+# Debugging
+
+To debug, install [Delve](https://github.com/derekparker/delve). Follow the installation 
+instructions for your OS, then you can run it like:
+
+```bash
+dlv debug main.go -- download -q "is:starred label:devchix" -l 10 -R
+```
+
+Note: The `--` separates `dlv` commandline args from the commandline args of the program being debugged. 
+
+
 ### Deleting index
 You can use `curl` to delete an email from the index using its id:
 ```bash
@@ -203,3 +215,4 @@ curl localhost:9200/mail/document/<id> > fixture.json
 
 Removing stuff you don't need for the test would be nice, too, as it would make it easier to find 
 relevant data in the fixture.
+

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,22 +1,28 @@
 package cmd
 
 import (
+  "fmt"
   "github.com/oaktown/calliope/gmailservice"
   "github.com/oaktown/calliope/misc"
   "github.com/oaktown/calliope/store"
   "github.com/spf13/cobra"
+  "html/template"
   "log"
+  "net/url"
+  "os"
   "strconv"
 )
 
 var limit, query, pageToken, inboxUrl string
+var runReport bool
 
 func init() {
   rootCmd.AddCommand(downloadCmd)
   downloadCmd.Flags().StringVarP(&limit, "limit", "l", "10", "limit number of emails to download (if > 500, rounds up to next multiple of 500).")
   downloadCmd.Flags().StringVarP(&query, "query", "q", "", "Gmail query. E.g. \"after: 2018/11/01 label:my-label is:starred\" More info: See https://support.google.com/mail/answer/7190.")
   downloadCmd.Flags().StringVarP(&pageToken, "page-token", "p", "", "Page token for downloading emails (probably going to be removed).")
-  downloadCmd.Flags().StringVarP(&inboxUrl, "inbox-url", "u", "https://mail.google.com/mail/#inbox/", "Url for gmail (useful if you are logged into multiple accounts).")
+  downloadCmd.Flags().StringVarP(&inboxUrl, "inbox-url", "u", "https://mail.google.com/mail/", "Url for gmail (useful if you are logged into multiple accounts).")
+  downloadCmd.Flags().BoolVarP(&runReport, "run-report", "R", false, "Runs a report instead of saving to Elasticsearch (in the future, this will be a different command altogether)")
 }
 
 var downloadCmd = &cobra.Command{
@@ -32,7 +38,7 @@ func reader(s store.Storable, messageChannel <-chan *gmailservice.Message, worke
   for message := range messageChannel { // reads from channel until it's closed
     workers <- true
     go func() {
-      defer func() { <- workers }()
+      defer func() { <-workers }()
       err := s.Save(*message)
       if err != nil {
         log.Println("Error saving: ", err)
@@ -40,6 +46,41 @@ func reader(s store.Storable, messageChannel <-chan *gmailservice.Message, worke
         log.Println("Saved:\n  ", message.Subject)
       }
     }()
+  }
+}
+
+type ReportData struct {
+  Query    string
+  Messages []*gmailservice.Message
+}
+
+func gmailUrl(threadId string) string {
+  return fmt.Sprintf("%v#search/%v/%v", inboxUrl, url.QueryEscape(query), threadId)
+}
+
+func jump(id string) string {
+  return fmt.Sprint("#", id)
+}
+
+func generateReport(s store.Storable, ch <-chan *gmailservice.Message) {
+
+  var messages []*gmailservice.Message
+  for msg := range ch {
+    messages = append(messages, msg)
+  }
+  log.Println("Messages found: ", len(messages))
+
+  report := template.Must(
+    template.New("report.html").
+      Funcs(template.FuncMap{
+        "gmailUrl": gmailUrl,
+        "jump":     jump,
+      }).
+      ParseFiles("report.html"))
+  data := ReportData{query, messages}
+  err := report.Execute(os.Stdout, data)
+  if err != nil {
+    log.Println("Error rendering template: ", err)
   }
 }
 
@@ -57,7 +98,11 @@ func download() {
   }
   d := gmailservice.New(gsvc, options, 200)
   gmailservice.Download(d)
-  reader(s, d.MessageChan, workers)
+  if runReport {
+    generateReport(s, d.MessageChan)
+  } else {
+    reader(s, d.MessageChan, workers)
+  }
 
   for i := 0; i < maxWorkers; i++ {
     workers <- true

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -9,12 +9,12 @@ import (
   "strconv"
 )
 
-var limit, lastDate, pageToken, inboxUrl string
+var limit, query, pageToken, inboxUrl string
 
 func init() {
   rootCmd.AddCommand(downloadCmd)
   downloadCmd.Flags().StringVarP(&limit, "limit", "l", "10", "limit number of emails to download (if > 500, rounds up to next multiple of 500).")
-  downloadCmd.Flags().StringVarP(&lastDate, "after-date", "d", "", "Emails after this date. In yyyy/mm/dd format.")
+  downloadCmd.Flags().StringVarP(&query, "query", "q", "", "Gmail query. E.g. \"after: 2018/11/01 label:my-label is:starred\" More info: See https://support.google.com/mail/answer/7190.")
   downloadCmd.Flags().StringVarP(&pageToken, "page-token", "p", "", "Page token for downloading emails (probably going to be removed).")
   downloadCmd.Flags().StringVarP(&inboxUrl, "inbox-url", "u", "https://mail.google.com/mail/#inbox/", "Url for gmail (useful if you are logged into multiple accounts).")
 }
@@ -51,8 +51,8 @@ func download() {
   gsvc := misc.GetGmailClient()
   s := misc.GetStoreClient()
   options := gmailservice.Options{
-    LastDate: lastDate,
-    Limit: max,
+    Query:    query,
+    Limit:    max,
     InboxUrl: inboxUrl,
   }
   d := gmailservice.New(gsvc, options, 200)

--- a/gmailservice/gmailservice.go
+++ b/gmailservice/gmailservice.go
@@ -10,15 +10,17 @@ import (
 )
 
 type Message struct {
-  Id      string
-  Url     string
-  Date    time.Time
-  To      string
-  Cc      string
-  From    string
-  Subject string
-  Body    string // the thing we're decoding
-  Source  gmail.Message
+  Id       string
+  Url      string
+  Date     time.Time
+  To       string
+  Cc       string
+  From     string
+  Subject  string
+  Body     string
+  ThreadId string
+  Snippet  string
+  Source   gmail.Message
 }
 
 type Downloader struct {
@@ -29,8 +31,8 @@ type Downloader struct {
   MaxWorkers   int
   Svc          *gmail.Service
   Options      Options
-  DoList func(*gmail.UsersMessagesListCall) (*gmail.ListMessagesResponse, error)
-  DoGet  func(request *gmail.UsersMessagesGetCall) (*gmail.Message, error)
+  DoList       func(*gmail.UsersMessagesListCall) (*gmail.ListMessagesResponse, error)
+  DoGet        func(request *gmail.UsersMessagesGetCall) (*gmail.Message, error)
 }
 
 type Options struct {
@@ -50,8 +52,8 @@ func New(svc *gmail.Service, options Options, maxWorkers int) Downloader {
     MaxWorkers:   maxWorkers,
     Svc:          svc,
     Options:      options,
-    DoList: DoList,
-    DoGet:  DoGet,
+    DoList:       DoList,
+    DoGet:        DoGet,
   }
 }
 
@@ -179,15 +181,17 @@ func GmailToMessage(gmail gmail.Message, inboxUrl string) (Message, error) {
   date := time.Unix(gmail.InternalDate/1000, 0)
   body := BodyText(gmail)
   message := Message{
-    Id:      gmail.Id,
-    Url:     fmt.Sprint(inboxUrl, gmail.ThreadId),
-    Date:    date,
-    To:      ExtractHeader(gmail, "To"),
-    Cc:      ExtractHeader(gmail, "Cc"),
-    From:    ExtractHeader(gmail, "From"),
-    Subject: ExtractHeader(gmail, "Subject"),
-    Body:    body,
-    Source:  gmail,
+    Id:       gmail.Id,
+    Url:      fmt.Sprintf("%v#inbox/%v", inboxUrl, gmail.ThreadId),
+    Date:     date,
+    To:       ExtractHeader(gmail, "To"),
+    Cc:       ExtractHeader(gmail, "Cc"),
+    From:     ExtractHeader(gmail, "From"),
+    Subject:  ExtractHeader(gmail, "Subject"),
+    Body:     body,
+    ThreadId: gmail.ThreadId,
+    Snippet:  gmail.Snippet,
+    Source:   gmail,
   }
   return message, nil
 }

--- a/gmailservice/gmailservice.go
+++ b/gmailservice/gmailservice.go
@@ -34,7 +34,7 @@ type Downloader struct {
 }
 
 type Options struct {
-  LastDate string
+  Query    string
   Limit    int64
   InboxUrl string
 }
@@ -76,8 +76,9 @@ func SearchMessages(d Downloader) {
   if d.Options.Limit > 0 {
     request = request.MaxResults(d.Options.Limit)
   }
-  if d.Options.LastDate != "" {
-    request = request.Q("after: " + d.Options.LastDate)
+  if d.Options.Query != "" {
+    log.Println("adding: ", d.Options.Query)
+    request = request.Q(d.Options.Query)
   }
   pageToken := ""
   for {
@@ -132,6 +133,7 @@ func DownloadFullMessage(d Downloader, id string) {
     log.Printf("Unable to decode message %v: %v", id, err)
     return
   }
+  log.Println("Subject: ", message.Subject)
   d.MessageChan <- &message
 }
 

--- a/report.html
+++ b/report.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Email report {{.Query}} </title>
+</head>
+<body>
+
+<h1 id="ToC">Table of Contents</h1>
+
+<table>
+    <thead>
+    <tr>
+        <th>Date</th>
+        <th>From</th>
+        <th>Gmail</th>
+        <th>Jump</th>
+        <th>Subject</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{range .Messages}}
+    <tr>
+        <td>{{.Date}}</td>
+        <td>{{.From}}</td>
+        <td><a href="{{.ThreadId | gmailUrl}}" target="_blank">Gmail</a></td>
+        <td><a href="{{.Id | jump}}">jump</a></td>
+        <td>{{.Subject}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+</table>
+
+<h2>Email messages</h2>
+
+<ul>
+    {{range .Messages}}
+    <li>
+        <table id="{{.Id}}">
+            <tr>
+                <th scope="row">Date</th>
+                <td>{{.Date}}</td>
+            </tr>
+            <tr>
+                <th scope="row">From</th>
+                <td>{{.From}}</td>
+            </tr>
+            <tr>
+                <th scope="row">To</th>
+                <td>{{.To}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Cc</th>
+                <td>{{.Cc}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Subject</th>
+                <td>{{.Subject}}</td>
+            </tr>
+        </table>
+        <div>
+            {{.Body}}
+        </div>
+        <ul>
+            <li>
+                <a href="#ToC">ToC</a>
+            </li>
+            <li>
+                <a href="{{.ThreadId | gmailUrl}}" target="_blank">Gmail</a>
+            </li>
+        </ul>
+    </li>
+    {{end}}
+</ul>
+</body>
+</html>

--- a/report/report.go
+++ b/report/report.go
@@ -1,9 +1,29 @@
 package report
 
 import (
+  "html/template"
+  "os"
+
   "google.golang.org/api/gmail/v1"
-)	
+)
 
 func Run(gmail *gmail.Service, label string) {
-
+  report := template.Must(template.ParseFiles("report.html"))
+  obj := struct{
+    foo string
+    bar int
+  }{"baz", 1}
+  report.Execute(os.Stdout, obj)
 }
+
+//URL:
+//
+//https://mail.google.com/mail/u/1/#search/{{query}}/{{threadid}}
+// As opposed to just linking to the thread, if you click on the back arrow, it'll put you in the search
+// for the label + star. Also, if there is a search term, it will highlight it.
+
+
+
+
+
+

--- a/store/store.go
+++ b/store/store.go
@@ -43,8 +43,8 @@ func New(ctx context.Context) (*Service, error) {
   }
 
   s := new(Service)
-  s.client = client;
-  s.ctx = ctx;
+  s.client = client
+  s.ctx = ctx
   return s, nil
 }
 
@@ -63,12 +63,12 @@ func (s *Service) Save(data gmailservice.Message) error {
     Id(data.Id).
     Type("document").
     BodyJson(string(json)).
-    Do(s.ctx);
+    Do(s.ctx)
   if err != nil {
     log.Printf("Failed to index data id %s in index %s, err: %v", data.Id, IndexName, err)
-    return err;
+    return err
   }
   log.Printf("Indexed data id %s to index %s, type %s\n", record.Id, record.Index, record.Type)
 
-  return nil;
+  return nil
 }


### PR DESCRIPTION
Fixes #8.

Be able to print reports for a particular search query. E.g.:

```bash
go run main.go download -q "label:devchix is:starred after:2018/06/01" -l 10 -R
```

Will generate a report (-R) with all the messages that have the label "devchix", are starred, and are dated after June 1, 2018, with the results limited to 10 at most). 