### PR TITLE
Report from Elasticsearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ data
 # IDE/editor files
 .idea
 
+# Temporary files
+tmp

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -22,7 +22,7 @@ func init() {
 var downloadCmd = &cobra.Command{
   Use:   "download",
   Short: "downloads emails",
-  Long:  `Downloads emails into Elasticsearch.`,
+  Long:  `Downloads emails from Gmail into Elasticsearch. Reports can then be run on the emails that have been downloaded.`,
   Run: func(cmd *cobra.Command, args []string) {
     download()
   },

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,15 +1,11 @@
 package cmd
 
 import (
-  "fmt"
   "github.com/oaktown/calliope/gmailservice"
   "github.com/oaktown/calliope/misc"
   "github.com/oaktown/calliope/store"
   "github.com/spf13/cobra"
-  "html/template"
   "log"
-  "net/url"
-  "os"
   "strconv"
 )
 
@@ -22,7 +18,6 @@ func init() {
   downloadCmd.Flags().StringVarP(&query, "query", "q", "", "Gmail query. E.g. \"after: 2018/11/01 label:my-label is:starred\" More info: See https://support.google.com/mail/answer/7190.")
   downloadCmd.Flags().StringVarP(&pageToken, "page-token", "p", "", "Page token for downloading emails (probably going to be removed).")
   downloadCmd.Flags().StringVarP(&inboxUrl, "inbox-url", "u", "https://mail.google.com/mail/", "Url for gmail (useful if you are logged into multiple accounts).")
-  downloadCmd.Flags().BoolVarP(&runReport, "run-report", "R", false, "Runs a report instead of saving to Elasticsearch (in the future, this will be a different command altogether)")
 }
 
 var downloadCmd = &cobra.Command{
@@ -49,41 +44,6 @@ func reader(s store.Storable, messageChannel <-chan *gmailservice.Message, worke
   }
 }
 
-type ReportData struct {
-  Query    string
-  Messages []*gmailservice.Message
-}
-
-func gmailUrl(threadId string) string {
-  return fmt.Sprintf("%v#search/%v/%v", inboxUrl, url.QueryEscape(query), threadId)
-}
-
-func jump(id string) string {
-  return fmt.Sprint("#", id)
-}
-
-func generateReport(s store.Storable, ch <-chan *gmailservice.Message) {
-
-  var messages []*gmailservice.Message
-  for msg := range ch {
-    messages = append(messages, msg)
-  }
-  log.Println("Messages found: ", len(messages))
-
-  report := template.Must(
-    template.New("report.html").
-      Funcs(template.FuncMap{
-        "gmailUrl": gmailUrl,
-        "jump":     jump,
-      }).
-      ParseFiles("report.html"))
-  data := ReportData{query, messages}
-  err := report.Execute(os.Stdout, data)
-  if err != nil {
-    log.Println("Error rendering template: ", err)
-  }
-}
-
 func download() {
   max, _ := strconv.ParseInt(limit, 10, 64)
   maxWorkers := 10
@@ -98,11 +58,7 @@ func download() {
   }
   d := gmailservice.New(gsvc, options, 200)
   gmailservice.Download(d)
-  if runReport {
-    generateReport(s, d.MessageChan)
-  } else {
-    reader(s, d.MessageChan, workers)
-  }
+  reader(s, d.MessageChan, workers)
 
   for i := 0; i < maxWorkers; i++ {
     workers <- true

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -34,7 +34,7 @@ func reader(s store.Storable, messageChannel <-chan *gmailservice.Message, worke
     workers <- true
     go func() {
       defer func() { <-workers }()
-      err := s.Save(*message)
+      err := s.SaveMessage(*message)
       if err != nil {
         log.Println("Error saving: ", err)
       } else {
@@ -57,7 +57,11 @@ func download() {
     InboxUrl: inboxUrl,
   }
   d := gmailservice.New(gsvc, options, 200)
-  gmailservice.Download(d)
+  labels := gmailservice.Download(d)
+  if err := s.SaveLabels(labels); err != nil {
+    log.Println("Error saving labels")
+  }
+
   reader(s, d.MessageChan, workers)
 
   for i := 0; i < maxWorkers; i++ {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -9,14 +9,13 @@ import (
   "strconv"
 )
 
-var limit, query, pageToken, inboxUrl string
+var limit, query, inboxUrl string
 var runReport bool
 
 func init() {
   rootCmd.AddCommand(downloadCmd)
   downloadCmd.Flags().StringVarP(&limit, "limit", "l", "10", "limit number of emails to download (if > 500, rounds up to next multiple of 500).")
   downloadCmd.Flags().StringVarP(&query, "query", "q", "", "Gmail query. E.g. \"after: 2018/11/01 label:my-label is:starred\" More info: See https://support.google.com/mail/answer/7190.")
-  downloadCmd.Flags().StringVarP(&pageToken, "page-token", "p", "", "Page token for downloading emails (probably going to be removed).")
   downloadCmd.Flags().StringVarP(&inboxUrl, "inbox-url", "u", "https://mail.google.com/mail/", "Url for gmail (useful if you are logged into multiple accounts).")
 }
 
@@ -29,7 +28,7 @@ var downloadCmd = &cobra.Command{
   },
 }
 
-func reader(s store.Storable, messageChannel <-chan *gmailservice.Message, workers chan bool) {
+func reader(s *store.Service, messageChannel <-chan *gmailservice.Message, workers chan bool) {
   for message := range messageChannel { // reads from channel until it's closed
     workers <- true
     go func() {

--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+  "fmt"
+  "github.com/oaktown/calliope/misc"
+  "github.com/oaktown/calliope/store"
+  "github.com/spf13/cobra"
+)
+
+var labelName string
+
+func init() {
+  rootCmd.AddCommand(labelsCmd)
+  labelsCmd.Flags().StringVarP(&labelName, "label", "l", "", "Look up the label id of a particular label.")
+
+}
+
+var labelsCmd = &cobra.Command{
+  Use:   "labels",
+  Short: "Get labels and ids from Elasticsearch",
+  Long:  `Get labels and ids from Elasticsearch. Must have downloaded earlier.`,
+  Run: func(cmd *cobra.Command, args []string) {
+    store := misc.GetStoreClient()
+    switch labelName == ""{
+    case false:
+      lookupLabel(store)
+    default:
+      showLabels(store)
+    }
+  },
+}
+
+func lookupLabel(store *store.Service) {
+  labelId, err := store.FindLabelId(labelName)
+  if err != nil {
+    fmt.Printf("Error looking up label %v: %v\n", labelName, err)
+  }
+  fmt.Println(labelId)
+}
+
+func showLabels(store *store.Service) {
+  labels, err := store.GetLabels()
+  if err != nil {
+    fmt.Println("Could not get labels from Elasticsearch. Error: ", err)
+  }
+  for _, label := range labels {
+
+    fmt.Printf("|%30s|%-30s|\n", label.Name, label.Id)
+  }
+}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -6,13 +6,16 @@ import (
   "github.com/oaktown/calliope/report"
 )
 
-var label string
+var label, esQuery string
+var allMessages bool
 
 func init() {
   rootCmd.AddCommand(reportCmd)
+  //reportCmd.Flags().StringVarP(&esQuery, "query", "q", "", "Elasticsearch query (overrides other flags).")
   reportCmd.Flags().StringVarP(&label, "label", "l", "",
-    "Report for emails with this label which are also starred (required).")
+    "Report for emails with this label (required).")
   reportCmd.MarkFlagRequired("label")
+  reportCmd.Flags().BoolVarP(&allMessages, "all-messages", "A", false, "By default, we only query for starred messages. With this flag, we get all messages for the label whether they are starred or not.")
 }
 
 var reportCmd = &cobra.Command{
@@ -23,6 +26,11 @@ specified label which are also starred (because the
 threaded UI in Gmail only allows applying labels to 
 threads).`,
   Run: func(cmd *cobra.Command, args []string) {
-    report.Run(misc.GetGmailClient(), label)
+    options := report.Options{
+      Label: label,
+      Starred: !allMessages,
+      Query: esQuery,
+    }
+    report.Run(misc.GetStoreClient(), options)
   },
 }

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -6,16 +6,18 @@ import (
   "github.com/oaktown/calliope/report"
 )
 
-var label, esQuery string
+var label, url string
 var allMessages bool
+var size int
 
 func init() {
   rootCmd.AddCommand(reportCmd)
-  //reportCmd.Flags().StringVarP(&esQuery, "query", "q", "", "Elasticsearch query (overrides other flags).")
   reportCmd.Flags().StringVarP(&label, "label", "l", "",
     "Report for emails with this label (required).")
   reportCmd.MarkFlagRequired("label")
   reportCmd.Flags().BoolVarP(&allMessages, "all-messages", "A", false, "By default, we only query for starred messages. With this flag, we get all messages for the label whether they are starred or not.")
+  reportCmd.Flags().IntVarP(&size, "size", "s", 1000, "The max number of results to return from a search. Defaults to 1000.")
+  downloadCmd.Flags().StringVarP(&url, "url", "U", "https://mail.google.com/mail/", "Url for gmail (useful if you are logged into multiple accounts).")
 }
 
 var reportCmd = &cobra.Command{
@@ -26,7 +28,8 @@ var reportCmd = &cobra.Command{
     options := report.Options{
       Label: label,
       Starred: !allMessages,
-      Query: esQuery,
+      InboxUrl: url,
+      Size: size,
     }
     report.Run(misc.GetStoreClient(), options)
   },

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -21,10 +21,7 @@ func init() {
 var reportCmd = &cobra.Command{
   Use:   "report",
   Short: "Creates an HTML report of labeled emails",
-  Long: `Creates an HTML report of emails with the 
-specified label which are also starred (because the 
-threaded UI in Gmail only allows applying labels to 
-threads).`,
+  Long: `Creates an HTML report of emails with the specified label which are also starred (because the threaded UI in Gmail only allows applying labels to threads). Report queries emails saved to Elasticsearch (as opposed to doing a search on Gmail).`,
   Run: func(cmd *cobra.Command, args []string) {
     options := report.Options{
       Label: label,

--- a/gmailservice/gmailservice.go
+++ b/gmailservice/gmailservice.go
@@ -19,6 +19,7 @@ type Message struct {
   Subject  string
   Body     string
   ThreadId string
+  LabelIds []string
   Snippet  string
   Source   gmail.Message
 }
@@ -65,7 +66,7 @@ func (d Downloader) NoNewWorkers() {
 }
 
 // Download everything that is requested in calliope generic Message format
-func Download(d Downloader) []*Label{
+func Download(d Downloader) []*Label {
   labels := DownloadLabels(d)
   go SearchMessages(d)
   go DownloadFullMessages(d)
@@ -213,6 +214,7 @@ func GmailToMessage(gmail gmail.Message, inboxUrl string) (Message, error) {
     Subject:  ExtractHeader(gmail, "Subject"),
     Body:     body,
     ThreadId: gmail.ThreadId,
+    LabelIds: gmail.LabelIds,
     Snippet:  gmail.Snippet,
     Source:   gmail,
   }

--- a/gmailservice/gmailservice.go
+++ b/gmailservice/gmailservice.go
@@ -33,6 +33,7 @@ type Downloader struct {
   Options      Options
   DoList       func(*gmail.UsersMessagesListCall) (*gmail.ListMessagesResponse, error)
   DoGet        func(request *gmail.UsersMessagesGetCall) (*gmail.Message, error)
+  DoListLabels func(call *gmail.UsersLabelsListCall) ()
 }
 
 type Options struct {
@@ -64,9 +65,31 @@ func (d Downloader) NoNewWorkers() {
 }
 
 // Download everything that is requested in calliope generic Message format
-func Download(d Downloader) {
+func Download(d Downloader) []*Label{
+  labels := DownloadLabels(d)
   go SearchMessages(d)
   go DownloadFullMessages(d)
+  return labels
+}
+
+type Label struct {
+  Id   string
+  Name string
+}
+
+func DownloadLabels(d Downloader) []*Label {
+  request := d.Svc.Users.Labels.List("me")
+  response, _ := request.Do()
+  var labels []*Label
+  for _, l := range response.Labels {
+    label := &Label{
+      Id:   l.Id,
+      Name: l.Name,
+    }
+    fmt.Printf("Id: %v\nName: %v\n\n", label.Id, label.Name)
+    labels = append(labels, label)
+  }
+  return labels
 }
 
 // SearchMessages gets list of message and thread IDs (not full message content)

--- a/report.html
+++ b/report.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Email report {{.Query}} </title>
+    <title>Email report {{.Label}}</title>
 </head>
 <body>
 

--- a/report/report.go
+++ b/report/report.go
@@ -12,8 +12,8 @@ import (
 type Options struct {
   Label    string
   Starred  bool
-  Query    string
   InboxUrl string
+  Size     int
 }
 
 type Data struct {
@@ -31,7 +31,7 @@ func Run(s *store.Service, options Options) {
     return fmt.Sprint("#", id)
   }
 
-  messages, err := s.GetMessages(options.Label, options.Starred)
+  messages, err := s.GetMessages(options.Label, options.Starred, options.Size)
   if err != nil {
     log.Println("Exiting due to error")
     return
@@ -52,4 +52,3 @@ func Run(s *store.Service, options Options) {
     log.Println("Error rendering template: ", err)
   }
 }
-

--- a/report/report.go
+++ b/report/report.go
@@ -1,29 +1,55 @@
 package report
 
 import (
+  "fmt"
+  "github.com/oaktown/calliope/gmailservice"
+  "github.com/oaktown/calliope/store"
   "html/template"
+  "log"
   "os"
-
-  "google.golang.org/api/gmail/v1"
 )
 
-func Run(gmail *gmail.Service, label string) {
-  report := template.Must(template.ParseFiles("report.html"))
-  obj := struct{
-    foo string
-    bar int
-  }{"baz", 1}
-  report.Execute(os.Stdout, obj)
+type Options struct {
+  Label    string
+  Starred  bool
+  Query    string
+  InboxUrl string
 }
 
-//URL:
-//
-//https://mail.google.com/mail/u/1/#search/{{query}}/{{threadid}}
-// As opposed to just linking to the thread, if you click on the back arrow, it'll put you in the search
-// for the label + star. Also, if there is a search term, it will highlight it.
+type Data struct {
+  Label    string
+  Messages []*gmailservice.Message
+}
 
+func Run(s *store.Service, options Options) {
 
+  gmailUrl := func(threadId string) string {
+    return fmt.Sprintf("%v#inbox/%v", options.InboxUrl, threadId)
+  }
 
+  jump := func(id string) string {
+    return fmt.Sprint("#", id)
+  }
 
+  messages, err := s.GetMessages(options.Label, options.Starred)
+  if err != nil {
+    log.Println("Exiting due to error")
+    return
+  }
 
+  report := template.Must(
+    template.New("report.html").
+      Funcs(template.FuncMap{
+        "gmailUrl": gmailUrl,
+        "jump":     jump,
+      }).
+      ParseFiles("report.html"))
+  data := Data{
+    Label:    options.Label,
+    Messages: messages,
+  }
+  if err := report.Execute(os.Stdout, data); err != nil {
+    log.Println("Error rendering template: ", err)
+  }
+}
 

--- a/store/store.go
+++ b/store/store.go
@@ -157,7 +157,7 @@ func (s *Service) FindLabelId(labelName string) (string, error) {
   return labelId, nil
 }
 
-func (s *Service) GetMessages(label string, starred bool) ([]*gmailservice.Message, error) {
+func (s *Service) GetMessages(label string, starred bool, size int) ([]*gmailservice.Message, error) {
   query, err := s.GenerateMessagesQuery(label, starred)
   if err != nil {
     log.Println("Query error: ", err)
@@ -167,6 +167,7 @@ func (s *Service) GetMessages(label string, starred bool) ([]*gmailservice.Messa
   result, err := s.Client.Search().
     Index(s.MailIndex).
     Query(query).
+    Size(size).
     Do(s.Ctx)
   if err != nil {
     log.Println("Couldn't search. Exiting")


### PR DESCRIPTION
Fixes #19 

Generate a report from data in Elasticsearch. Adds `report` command that has a required option `-l` to specify the label. By default only matches starred messages w/ label, but with `-A` will match all messages, starred or not.