### PR TITLE
Exclude from config

### DIFF
--- a/calliope-example.yml
+++ b/calliope-example.yml
@@ -1,0 +1,15 @@
+---
+exclude_headers_with_values:
+  From:
+    - noreply
+    - no-reply
+  Sender:
+    - noreply
+    - no-reply
+  List-Unsubscribe:
+  List-ID:
+  X-Feedback-ID:
+  Feedback-ID:
+  X-MailingID:
+  x-blast-id:
+  X-BBounce:

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+  "fmt"
   "github.com/oaktown/calliope/gmailservice"
   "github.com/oaktown/calliope/misc"
   "github.com/oaktown/calliope/store"
   "github.com/spf13/cobra"
+  "github.com/spf13/viper"
   "log"
   "strconv"
 )
@@ -51,16 +53,22 @@ func reader(s *store.Service, messageChannel <-chan *gmailservice.Message, maxWo
 }
 
 func download() {
+  exclude_headers := viper.GetStringMapStringSlice("exclude_headers_with_values")
+  for k, v := range exclude_headers {
+   fmt.Printf("key: %s\n", k)
+   for _, s := range v {
+   fmt.Printf("  %s\n", s)
+   }
+  }
   max, _ := strconv.ParseInt(limit, 10, 64)
-  maxWorkers := 10
-  workers := make(chan bool, maxWorkers)
 
   gsvc := misc.GetGmailClient()
   s := misc.GetStoreClient()
   options := gmailservice.Options{
-    Query:    query,
-    Limit:    max,
-    InboxUrl: inboxUrl,
+    Query:          query,
+    Limit:          max,
+    InboxUrl:       inboxUrl,
+    ExcludeHeaders: exclude_headers,
   }
   d := gmailservice.New(gsvc, options, 200)
   labels := gmailservice.Download(d)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,8 @@ func initConfig() {
 
 		// Search config in home directory with name ".calliope" (without extension).
 		viper.AddConfigPath(home)
-		viper.SetConfigName(".calliope")
+		viper.AddConfigPath(".") // working directory
+		viper.SetConfigName("calliope")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match


### PR DESCRIPTION
Allows you to exclude messages from being saved in Elasticsearch. This is especially useful if you get a lot of emails from mailing lists or alerting services that aren't interesting for analysis in Calliope.