### PR TITLE
[#37] Turn x-axis labels sideways.

### DIFF
--- a/templates/report.html
+++ b/templates/report.html
@@ -94,7 +94,7 @@
 
 <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
 <script>
-    var margin = {top: 20, right: 30, bottom: 30, left: 40},
+    var margin = {top: 20, right: 30, bottom: 60, left: 40},
         width = 960 - margin.left - margin.right,
         height = 500 - margin.top - margin.bottom;
 
@@ -124,7 +124,14 @@
     chart.append("g")
         .attr("class", "x axis")
         .attr("transform", "translate(0," + height + ")")
-        .call(xAxis);
+        .call(xAxis)
+        .selectAll("text")
+            .style("text-anchor", "end")
+            .attr("dx", "-.8em")
+            .attr("dy", ".15em")
+            .attr("transform", function(d) {
+                return "rotate(-65)";
+            });
 
     chart.append("g")
         .attr("class", "y axis")

--- a/templates/report.html
+++ b/templates/report.html
@@ -3,6 +3,10 @@
         fill: steelblue;
     }
 
+    .bar:hover {
+        fill: #12538A;
+    }
+
     .axis text {
         font: 10px sans-serif;
     }

--- a/templates/report.html
+++ b/templates/report.html
@@ -114,6 +114,7 @@
 
     var yAxis = d3.svg.axis()
         .scale(y)
+        .tickFormat(d3.format("d"))
         .orient("left");
 
     var chart = d3.select(".chart")


### PR DESCRIPTION
- #37: turn x-axis labels sideways.
- Bar changes color on hover. (No tooltip yet.)
- Y-axis labels only show integer values. (For sufficiently small y-axis values, tick marks for decimal values remain.)