### PR TITLE
Retry on failure (up to 3 times)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,6 +53,14 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:75ab90ae3f5d876167e60f493beadfe66f0ed861a710f283fb06c86437a09538"
+  name = "github.com/jonboulle/clockwork"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2eee05ed794112d45db504eb05aa693efd2b8b09"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
   name = "github.com/magiconair/properties"
   packages = ["."]
@@ -260,6 +268,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/jonboulle/clockwork",
     "github.com/mitchellh/go-homedir",
     "github.com/olivere/elastic",
     "github.com/spf13/cobra",
@@ -268,6 +277,7 @@
     "golang.org/x/oauth2",
     "golang.org/x/oauth2/google",
     "google.golang.org/api/gmail/v1",
+    "google.golang.org/api/googleapi",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -163,18 +163,22 @@ curl -XDELETE localhost:9200/mail
 To run tests:
 
 ```bash
-go test ./gmailservice
+go test -v ./...
 ```
 
-Note: If you find a problematic email and want to download it locally e.g. to add as a test fixture, 
-you can get it using curl, too:
+The `-v` option is optional; it provides more info and also ignores test cache. The `./..`
+means to run all tests. Alternatively, you can provide a path to the package (e.g. 
+`./gmailservice`).   
+
+Note: If you find a problematic email and want to download it locally e.g. to add as a test
+fixture, you can get it using curl:
 
 ```bash
 curl localhost:9200/mail/document/<id> > fixture.json
 ```
 
-Removing stuff you don't need for the test would be nice, too, as it would make it easier to find 
-relevant data in the fixture.
+Removing stuff you don't need for the test would be nice, too, as it would make it easier to
+find relevant data in the fixture.
 
 ## Debugging
    
@@ -186,3 +190,13 @@ dlv debug main.go -- download -q "is:starred label:devchix" -l 10 -R
 ```
 
 Note: The `--` separates `dlv` commandline args from the commandline args of the program being debugged. 
+
+To debug tests that have fixtures, you will need to change the working directory:
+
+```bash
+cd gmailservice
+dlv test . -- -test.v
+``` 
+
+If you don't change working directories, it'll have trouble finding fixture. Also, `./..` 
+from the project root doesn't work.

--- a/gmailservice/gmailservice.go
+++ b/gmailservice/gmailservice.go
@@ -50,6 +50,7 @@ func New(svc *gmail.Service, options Options, maxWorkers int) Downloader {
     doGet:          doGet,
     GmailToMessage: GmailToMessage,
     StartedAt:      time.Now(),
+    clock: clockwork.NewRealClock(),
   }
 }
 

--- a/gmailservice/gmailservice_test.go
+++ b/gmailservice/gmailservice_test.go
@@ -9,6 +9,7 @@ import (
   "log"
   "net/http"
   "os"
+  "strconv"
   "strings"
   "sync"
   "testing"
@@ -85,13 +86,38 @@ func TestDownloadFullMessages(t *testing.T) {
     Header: make(http.Header),
   }
 
-  tooManyRequests429 := func() {
-    var total429s int
+  type results struct {
+    failures  int
+    successes int
+  }
+
+  type allResults struct {
+    firstAdvance  results
+    secondAdvance results
+    finalAdvance  results
+  }
+
+  testWith429s := func(expected allResults, secsBeforeOk time.Duration) {
+    var total429s, total200s int
+    var messages, partialMessages []*store.Message
+    startTimeStr := "2018-12-01 0:00:00 PST"
+    maxWorkers := 3
+    finalAdvance := 90 * time.Second
+    verify429sAnd200s := func(failures, successes int) {
+      if total429s != failures {
+        t.Errorf("Expected %v 429 responses. Instead, got %v", failures, total429s)
+      }
+      if total200s != successes {
+        t.Errorf("Expected %v successful downloads. Instead, got %v", successes, total200s)
+      }
+    }
 
     failsFor := func(start time.Time, secs time.Duration) func(*Downloader, string) (*gmail.Message, error) {
-      ok := start.Add(time.Duration(secs) * time.Second)
+      ok := start.Add(secs * time.Second)
       return func(d *Downloader, id string) (*gmail.Message, error) {
-        if !d.clock.Now().Before(ok) {
+        now := d.clock.Now()
+        if !now.Before(ok) {
+          total200s++
           return fakeGmailMessage(id, "Successfully downloaded"), nil
         }
         total429s++
@@ -101,53 +127,52 @@ func TestDownloadFullMessages(t *testing.T) {
 
     // Test Downloader with time and network calls stubbed out
     layout := "2006-01-02 15:04:05 MST"
-    start, _ := time.Parse(layout, "2018-12-01 0:00:00 PST")
+    start, _ := time.Parse(layout, startTimeStr)
     fakeClock := clockwork.NewFakeClockAt(start)
-    downloader := New(nil, Options{}, 3)
+    downloader := New(nil, Options{}, maxWorkers)
     downloader.clock = fakeClock
-    downloader.doGet = failsFor(start, 59)
+    downloader.doGet = failsFor(start, secsBeforeOk)
     var wg sync.WaitGroup
     wg.Add(1)
     go func() {
       DownloadFullMessages(downloader)
       wg.Done()
     }()
-    downloader.SearchChan <- fakeGmailMessage("1", "")
-    downloader.SearchChan <- fakeGmailMessage("2", "")
-    downloader.SearchChan <- fakeGmailMessage("3", "")
-    close(downloader.SearchChan)
+    wg.Add(1)
+    go func() {
+      for m := range downloader.MessageChan {
+        //fmt.Println("TTTT Subject:", m.Subject)
+        if m.Subject == "Successfully downloaded" {
+          messages = append(messages, m)
+        } else {
+          partialMessages = append(partialMessages, m)
+        }
+      }
+      wg.Done()
+    }()
 
+    go func() {
+      for i := 1; i <= maxWorkers; i++ {
+        downloader.SearchChan <- fakeGmailMessage(strconv.Itoa(i), "")
+      }
+      close(downloader.SearchChan)
+    }()
     // Wait until all three goroutines have called Sleep the first time
-    fakeClock.BlockUntil(3)
-
-    if total429s != 3 {
-      t.Errorf("Expected 3 429 responses. Instead, got %v", total429s)
-    }
-
-    if len(downloader.MessageChan) > 0 {
-      t.Errorf("Expected 0 downloads (because of 429s). Instead, got %v", len(downloader.MessageChan))
-    }
+    fakeClock.BlockUntil(maxWorkers)
+    verify429sAnd200s(expected.firstAdvance.failures, expected.firstAdvance.successes)
 
     // Advance fakeClock to first retry (still before the time we start responding w/ 200s)
     fakeClock.Advance(30 * time.Second)
-
     // Wait until all three goroutines have called Sleep the second time
-    fakeClock.BlockUntil(3)
+    fakeClock.BlockUntil(maxWorkers)
+    verify429sAnd200s(expected.secondAdvance.failures, expected.secondAdvance.successes)
 
-    if total429s != 6 {
-      t.Errorf("Expected 6 429 responses. Instead, got %v", total429s)
-    }
-
-    // Advance fakeClock into the time we respond with 200
-    fakeClock.Advance(120 * time.Second)
-    var messages []*store.Message
-    for m := range downloader.MessageChan {
-      messages = append(messages, m)
-    }
-
+    // Advance fakeClock into the time we respond with 200s, and grab all messages before final verification
+    fakeClock.Advance(finalAdvance)
     wg.Wait()
-    if len(messages) != 3 {
-      t.Errorf("Expected 3 successful downloads. Instead, got %v", len(messages))
+    verify429sAnd200s(expected.finalAdvance.failures, expected.finalAdvance.successes)
+    if len(messages) != expected.finalAdvance.successes {
+      t.Errorf("Expected %v successful downloads. Instead, got %v", expected.finalAdvance.successes, len(messages))
     }
   }
 
@@ -158,8 +183,46 @@ func TestDownloadFullMessages(t *testing.T) {
     verify func()
   }{
     {
-      name:   "Test incremental back off when API usage exceeded",
-      verify: tooManyRequests429,
+      name: "Test incremental back off when API usage exceeded",
+      verify: func() {
+        testWith429s(
+          allResults{
+            firstAdvance: results{
+              failures:  3,
+              successes: 0,
+            },
+            secondAdvance: results{
+              failures:  6,
+              successes: 0,
+            },
+            finalAdvance: results{
+              failures:  6,
+              successes: 3,
+            },
+          }, 59,
+        )
+      },
+    },
+    {
+      name: "Test unavailable API",
+      verify: func() {
+        testWith429s(
+          allResults{
+            firstAdvance: results{
+              failures:  3,
+              successes: 0,
+            },
+            secondAdvance: results{
+              failures:  6,
+              successes: 0,
+            },
+            finalAdvance: results{
+              failures:  9,
+              successes: 0,
+            },
+          }, 180,
+        )
+      },
     },
   }
   for _, tt := range tests {

--- a/gmailservice/gmailservice_test.go
+++ b/gmailservice/gmailservice_test.go
@@ -2,11 +2,17 @@ package gmailservice
 
 import (
   "encoding/json"
+  "github.com/jonboulle/clockwork"
+  "github.com/oaktown/calliope/store"
+  "google.golang.org/api/googleapi"
   "io/ioutil"
   "log"
+  "net/http"
   "os"
   "strings"
+  "sync"
   "testing"
+  "time"
 
   "google.golang.org/api/gmail/v1"
 )
@@ -46,11 +52,117 @@ func TestBodyText(t *testing.T) {
 func TestGmailToMessage(t *testing.T) {
   emailJson := getEmailJson()
   rawGmail, _ := JsonToGmail(emailJson)
-  msg, err := GmailToMessage(rawGmail, "https://mail.google.com/mail/#inbox")
+  msg, err := GmailToMessage(rawGmail, "https://mail.google.com/mail/#inbox", time.Now())
   if err != nil {
     t.Errorf("Unexpected error calling JsonForElasticsearch: %v", err)
   }
   if body := msg.Body; !strings.Contains(body, expectedBody) {
     t.Errorf("Body is incorrect. Should have been:\n\n%v\n\nInstead, got:\n\n%v\n\n", expectedBody, body)
+  }
+}
+
+func TestDownloadFullMessages(t *testing.T) {
+
+  fakeGmailMessage := func(id, subject string) *gmail.Message {
+    return &gmail.Message{
+      Id: id,
+      Payload: &gmail.MessagePart{
+        Headers: []*gmail.MessagePartHeader{
+          {
+            Name:  "Subject",
+            Value: subject,
+          },
+        },
+        Body: &gmail.MessagePartBody{
+          Data: "",
+        },
+      },
+    }
+  }
+
+  err429 := &googleapi.Error{
+    Code:   429,
+    Header: make(http.Header),
+  }
+
+  tooManyRequests429 := func() {
+    var total429s int
+
+    failsFor := func(start time.Time, secs time.Duration) func(*Downloader, string) (*gmail.Message, error) {
+      ok := start.Add(time.Duration(secs) * time.Second)
+      return func(d *Downloader, id string) (*gmail.Message, error) {
+        if !d.clock.Now().Before(ok) {
+          return fakeGmailMessage(id, "Successfully downloaded"), nil
+        }
+        total429s++
+        return nil, err429
+      }
+    }
+
+    // Test Downloader with time and network calls stubbed out
+    layout := "2006-01-02 15:04:05 MST"
+    start, _ := time.Parse(layout, "2018-12-01 0:00:00 PST")
+    fakeClock := clockwork.NewFakeClockAt(start)
+    downloader := New(nil, Options{}, 3)
+    downloader.clock = fakeClock
+    downloader.doGet = failsFor(start, 59)
+    var wg sync.WaitGroup
+    wg.Add(1)
+    go func() {
+      DownloadFullMessages(downloader)
+      wg.Done()
+    }()
+    downloader.SearchChan <- fakeGmailMessage("1", "")
+    downloader.SearchChan <- fakeGmailMessage("2", "")
+    downloader.SearchChan <- fakeGmailMessage("3", "")
+    close(downloader.SearchChan)
+
+    // Wait until all three goroutines have called Sleep the first time
+    fakeClock.BlockUntil(3)
+
+    if total429s != 3 {
+      t.Errorf("Expected 3 429 responses. Instead, got %v", total429s)
+    }
+
+    if len(downloader.MessageChan) > 0 {
+      t.Errorf("Expected 0 downloads (because of 429s). Instead, got %v", len(downloader.MessageChan))
+    }
+
+    // Advance fakeClock to first retry (still before the time we start responding w/ 200s)
+    fakeClock.Advance(30 * time.Second)
+
+    // Wait until all three goroutines have called Sleep the second time
+    fakeClock.BlockUntil(3)
+
+    if total429s != 6 {
+      t.Errorf("Expected 6 429 responses. Instead, got %v", total429s)
+    }
+
+    // Advance fakeClock into the time we respond with 200
+    fakeClock.Advance(120 * time.Second)
+    var messages []*store.Message
+    for m := range downloader.MessageChan {
+      messages = append(messages, m)
+    }
+
+    wg.Wait()
+    if len(messages) != 3 {
+      t.Errorf("Expected 3 successful downloads. Instead, got %v", len(messages))
+    }
+  }
+
+  // Kind of unnecessary since we only have one test, but leaving it this way to make it easy to
+  // add additional test scenarios.
+  tests := []struct {
+    name   string
+    verify func()
+  }{
+    {
+      name:   "Test incremental back off when API usage exceeded",
+      verify: tooManyRequests429,
+    },
+  }
+  for _, tt := range tests {
+    tt.verify()
   }
 }

--- a/store/store.go
+++ b/store/store.go
@@ -52,11 +52,11 @@ func New(ctx context.Context) (*Service, error) {
   }
 
   if err := createIndex(MailIndex, client, ctx); err != nil {
-    log.Println("Error creating %v index: %v", MailIndex, err)
+    log.Printf("Error creating %v index: %v\n", MailIndex, err)
     return nil, err
   }
   if err := createIndex(LabelsIndex, client, ctx); err != nil {
-    log.Println("Error creating %v index: %v", LabelsIndex, err)
+    log.Printf("Error creating %v index: %v\n", LabelsIndex, err)
     return nil, err
   }
 

--- a/store/store.go
+++ b/store/store.go
@@ -27,7 +27,7 @@ type Message struct {
   Date                time.Time
   DownloadedStartedAt time.Time
   To                  string
-  Cc                  string
+  Cc                   string
   From                string
   Subject             string
   Snippet             string

--- a/vendor/github.com/jonboulle/clockwork/.gitignore
+++ b/vendor/github.com/jonboulle/clockwork/.gitignore
@@ -1,0 +1,25 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+
+*.swp

--- a/vendor/github.com/jonboulle/clockwork/.travis.yml
+++ b/vendor/github.com/jonboulle/clockwork/.travis.yml
@@ -1,0 +1,5 @@
+language: go
+go:
+  - 1.3
+
+sudo: false

--- a/vendor/github.com/jonboulle/clockwork/LICENSE
+++ b/vendor/github.com/jonboulle/clockwork/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/jonboulle/clockwork/README.md
+++ b/vendor/github.com/jonboulle/clockwork/README.md
@@ -1,0 +1,61 @@
+clockwork
+=========
+
+[![Build Status](https://travis-ci.org/jonboulle/clockwork.png?branch=master)](https://travis-ci.org/jonboulle/clockwork)
+[![godoc](https://godoc.org/github.com/jonboulle/clockwork?status.svg)](http://godoc.org/github.com/jonboulle/clockwork) 
+
+a simple fake clock for golang
+
+# Usage
+
+Replace uses of the `time` package with the `clockwork.Clock` interface instead.
+
+For example, instead of using `time.Sleep` directly:
+
+```
+func my_func() {
+	time.Sleep(3 * time.Second)
+	do_something()
+}
+```
+
+inject a clock and use its `Sleep` method instead:
+
+```
+func my_func(clock clockwork.Clock) {
+	clock.Sleep(3 * time.Second)
+	do_something()
+}
+```
+
+Now you can easily test `my_func` with a `FakeClock`:
+
+```
+func TestMyFunc(t *testing.T) {
+	c := clockwork.NewFakeClock()
+
+	// Start our sleepy function
+	my_func(c)
+
+	// Ensure we wait until my_func is sleeping
+	c.BlockUntil(1)
+
+	assert_state()
+
+	// Advance the FakeClock forward in time
+	c.Advance(3)
+
+	assert_state()
+}
+```
+
+and in production builds, simply inject the real clock instead:
+```
+my_func(clockwork.NewRealClock())
+```
+
+See [example_test.go](example_test.go) for a full example.
+
+# Credits
+
+clockwork is inspired by @wickman's [threaded fake clock](https://gist.github.com/wickman/3840816), and the [Golang playground](http://blog.golang.org/playground#Faking time)

--- a/vendor/github.com/jonboulle/clockwork/clockwork.go
+++ b/vendor/github.com/jonboulle/clockwork/clockwork.go
@@ -1,0 +1,169 @@
+package clockwork
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock provides an interface that packages can use instead of directly
+// using the time module, so that chronology-related behavior can be tested
+type Clock interface {
+	After(d time.Duration) <-chan time.Time
+	Sleep(d time.Duration)
+	Now() time.Time
+}
+
+// FakeClock provides an interface for a clock which can be
+// manually advanced through time
+type FakeClock interface {
+	Clock
+	// Advance advances the FakeClock to a new point in time, ensuring any existing
+	// sleepers are notified appropriately before returning
+	Advance(d time.Duration)
+	// BlockUntil will block until the FakeClock has the given number of
+	// sleepers (callers of Sleep or After)
+	BlockUntil(n int)
+}
+
+// NewRealClock returns a Clock which simply delegates calls to the actual time
+// package; it should be used by packages in production.
+func NewRealClock() Clock {
+	return &realClock{}
+}
+
+// NewFakeClock returns a FakeClock implementation which can be
+// manually advanced through time for testing. The initial time of the
+// FakeClock will be an arbitrary non-zero time.
+func NewFakeClock() FakeClock {
+	// use a fixture that does not fulfill Time.IsZero()
+	return NewFakeClockAt(time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC))
+}
+
+// NewFakeClockAt returns a FakeClock initialised at the given time.Time.
+func NewFakeClockAt(t time.Time) FakeClock {
+	return &fakeClock{
+		time: t,
+	}
+}
+
+type realClock struct{}
+
+func (rc *realClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+func (rc *realClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (rc *realClock) Now() time.Time {
+	return time.Now()
+}
+
+type fakeClock struct {
+	sleepers []*sleeper
+	blockers []*blocker
+	time     time.Time
+
+	l sync.RWMutex
+}
+
+// sleeper represents a caller of After or Sleep
+type sleeper struct {
+	until time.Time
+	done  chan time.Time
+}
+
+// blocker represents a caller of BlockUntil
+type blocker struct {
+	count int
+	ch    chan struct{}
+}
+
+// After mimics time.After; it waits for the given duration to elapse on the
+// fakeClock, then sends the current time on the returned channel.
+func (fc *fakeClock) After(d time.Duration) <-chan time.Time {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	now := fc.time
+	done := make(chan time.Time, 1)
+	if d.Nanoseconds() == 0 {
+		// special case - trigger immediately
+		done <- now
+	} else {
+		// otherwise, add to the set of sleepers
+		s := &sleeper{
+			until: now.Add(d),
+			done:  done,
+		}
+		fc.sleepers = append(fc.sleepers, s)
+		// and notify any blockers
+		fc.blockers = notifyBlockers(fc.blockers, len(fc.sleepers))
+	}
+	return done
+}
+
+// notifyBlockers notifies all the blockers waiting until the
+// given number of sleepers are waiting on the fakeClock. It
+// returns an updated slice of blockers (i.e. those still waiting)
+func notifyBlockers(blockers []*blocker, count int) (newBlockers []*blocker) {
+	for _, b := range blockers {
+		if b.count == count {
+			close(b.ch)
+		} else {
+			newBlockers = append(newBlockers, b)
+		}
+	}
+	return
+}
+
+// Sleep blocks until the given duration has passed on the fakeClock
+func (fc *fakeClock) Sleep(d time.Duration) {
+	<-fc.After(d)
+}
+
+// Time returns the current time of the fakeClock
+func (fc *fakeClock) Now() time.Time {
+	fc.l.RLock()
+	t := fc.time
+	fc.l.RUnlock()
+	return t
+}
+
+// Advance advances fakeClock to a new point in time, ensuring channels from any
+// previous invocations of After are notified appropriately before returning
+func (fc *fakeClock) Advance(d time.Duration) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	end := fc.time.Add(d)
+	var newSleepers []*sleeper
+	for _, s := range fc.sleepers {
+		if end.Sub(s.until) >= 0 {
+			s.done <- end
+		} else {
+			newSleepers = append(newSleepers, s)
+		}
+	}
+	fc.sleepers = newSleepers
+	fc.blockers = notifyBlockers(fc.blockers, len(fc.sleepers))
+	fc.time = end
+}
+
+// BlockUntil will block until the fakeClock has the given number of sleepers
+// (callers of Sleep or After)
+func (fc *fakeClock) BlockUntil(n int) {
+	fc.l.Lock()
+	// Fast path: current number of sleepers is what we're looking for
+	if len(fc.sleepers) == n {
+		fc.l.Unlock()
+		return
+	}
+	// Otherwise, set up a new blocker
+	b := &blocker{
+		count: n,
+		ch:    make(chan struct{}),
+	}
+	fc.blockers = append(fc.blockers, b)
+	fc.l.Unlock()
+	<-b.ch
+}


### PR DESCRIPTION
Retries up to 3 times, with a longer wait each time (we chose incremental backoff with a higher initial delay over exponential backoff with a lower initial delay). Also, for downloads that fail all retries, we add mostly blank record to message channel with enough info to redownload (see #51). Plus improved logging.

Includes an integration test (TestDownloadFullMessages) that tests incremental backoff. We chose to do incremental with a higher initial duration instead of exponential with a lower initial duration.

Resolves #41 
