### PR TITLE
labels cmd -o shows only user labels

### DIFF
--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -5,14 +5,16 @@ import (
   "github.com/oaktown/calliope/misc"
   "github.com/oaktown/calliope/store"
   "github.com/spf13/cobra"
+  "log"
 )
 
 var labelName string
+var userLabelsOnly bool
 
 func init() {
   rootCmd.AddCommand(labelsCmd)
   labelsCmd.Flags().StringVarP(&labelName, "label", "l", "", "Look up the label id of a particular label.")
-
+  labelsCmd.Flags().BoolVarP(&userLabelsOnly, "only", "o", false, "Display only user labels.")
 }
 
 var labelsCmd = &cobra.Command{
@@ -21,7 +23,7 @@ var labelsCmd = &cobra.Command{
   Long:  `Get labels and ids from Elasticsearch. Must have downloaded earlier.`,
   Run: func(cmd *cobra.Command, args []string) {
     store := misc.GetStoreClient()
-    switch labelName == ""{
+    switch labelName == "" {
     case false:
       lookupLabel(store)
     default:
@@ -33,18 +35,17 @@ var labelsCmd = &cobra.Command{
 func lookupLabel(store *store.Service) {
   labelId, err := store.FindLabelId(labelName)
   if err != nil {
-    fmt.Printf("Error looking up label %v: %v\n", labelName, err)
+    log.Printf("Error looking up label %v: %v\n", labelName, err)
   }
   fmt.Println(labelId)
 }
 
 func showLabels(store *store.Service) {
-  labels, err := store.GetLabels()
+  labels, err := store.GetLabels(userLabelsOnly)
   if err != nil {
-    fmt.Println("Could not get labels from Elasticsearch. Error: ", err)
+    log.Println("Could not get labels from Elasticsearch. Error: ", err)
   }
   for _, label := range labels {
-
     fmt.Printf("|%30s|%-30s|\n", label.Name, label.Id)
   }
 }

--- a/store/labels.go
+++ b/store/labels.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"github.com/olivere/elastic"
+	"encoding/json"
+	"log"
+)
+
+type Label struct {
+  Id   string
+  Name string
+}
+
+const LabelsIndex = "labels"
+
+type LabelsDoc struct {
+  Id     string
+  Labels []*Label
+}
+
+func (s *Service) SaveLabels(labels []*Label) error {
+  doc := LabelsDoc{
+    Id:     "labels",
+    Labels: labels,
+  }
+  labelsJson, _ := json.MarshalIndent(doc, "", "\t")
+
+  if _, err := s.saveDoc(LabelsIndex, "labels", string(labelsJson)); err != nil {
+    return err
+  }
+
+  return nil
+}
+
+func (s *Service) getLabelsFromStore() ([]*Label, error) {
+  var doc LabelsDoc
+  query := elastic.NewTermQuery("Id", "labels")
+  result, _ := s.Client.Search().
+    Index(LabelsIndex).
+    Query(query).
+    Do(s.Ctx)
+  labelsJson := result.Hits.Hits[0].Source
+  if err := json.Unmarshal(*labelsJson, &doc); err != nil {
+    log.Println("Unable to unmarshal labels json. err: ", err)
+    return nil, err
+  }
+  return doc.Labels, nil
+}
+
+var googleLabel = map[string]bool{
+	"CATEGORY_PERSONAL": true,
+	"IMPORTANT": true,
+	"CHAT": true,
+	"SENT": true,
+	"INBOX": true,
+	"TRASH": true,
+	"DRAFT": true,
+	"SPAM": true,
+	"STARRED": true,
+	"UNREAD": true,
+	"CATEGORY_FORUMS": true,
+	"CATEGORY_SOCIAL": true,
+	"CATEGORY_UPDATES": true,
+	"CATEGORY_PROMOTIONS": true,
+	"[Imap]/Drafts": true,
+	"[Imap]/Archive": true,
+	"Deleted Messages": true,
+}
+
+func (s *Service) GetLabels(userOnly bool) ([]*Label, error) {
+	labels, err := s.getLabelsFromStore();
+	if err != nil {
+		// TODO: handle error
+	}
+	if userOnly {
+		userLabels := labels[:0]
+		for _, label := range labels {
+			if !googleLabel[label.Name] {
+				userLabels = append(userLabels, label)
+			}
+		}
+		return userLabels, nil;
+	}
+	return labels, nil;
+}


### PR DESCRIPTION
`go run main.go labels -o` will show only the user-defined labels (omitting gmail built-in labels)