### PR TITLE
Collapse/expand message summaries

### DIFF
--- a/client/calliope/elm.json
+++ b/client/calliope/elm.json
@@ -17,6 +17,7 @@
             "elm-community/typed-svg": "5.0.1",
             "gampleman/elm-visualization": "2.0.0",
             "justinmimbs/date": "3.1.2",
+            "mdgriffith/elm-ui": "1.1.0",
             "rtfeldman/elm-iso8601-date-strings": "1.1.2",
             "ryannhg/date-format": "2.3.0"
         },

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -338,7 +338,7 @@ viewSearchForm model =
             { onChange = \str -> UpdateSearch (Participants str)
             , text = model.participants
             , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Participants (applies to From:, To:, and CC:):")
+            , label = Input.labelAbove [] (E.text "Participants (applies to From, To, and CC)")
             }
         , Input.text []
             { onChange = \str -> UpdateSearch (BodyOrSubject str)
@@ -350,49 +350,49 @@ viewSearchForm model =
             { onChange = \str -> UpdateSearch (StartDate str)
             , text = model.startDate
             , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Start date (\"YYYY-MM-DD\"):")
+            , label = Input.labelAbove [] (E.text "Start date (\"YYYY-MM-DD\")")
             }
         , Input.text []
             { onChange = \str -> UpdateSearch (EndDate str)
             , text = model.endDate
             , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "End date (\"YYYY-MM-DD\"):")
+            , label = Input.labelAbove [] (E.text "End date (\"YYYY-MM-DD\")")
             }
         , Input.text []
             { onChange = \str -> UpdateSearch (TimeZone str)
             , text = model.timeZone
             , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Time zone (e.g. -0800 for PST):")
+            , label = Input.labelAbove [] (E.text "Time zone (e.g. -0800 for PST)")
             }
         , Input.text []
             { onChange = \str -> UpdateSearch (Label str)
             , text = model.label
             , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Label:")
+            , label = Input.labelAbove [] (E.text "Label")
             }
         , Input.checkbox []
             { onChange = \b -> UpdateSearch StarredOnly
             , icon = onOffSwitch
             , checked = model.starredOnly
-            , label = Input.labelLeft [] (E.text "Starred only:")
+            , label = Input.labelLeft [] (E.text "Starred only")
             }
         , Input.text []
             { onChange = \str -> UpdateSearch (SortField str)
             , text = model.sortField
             , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Sort field:")
+            , label = Input.labelAbove [] (E.text "Sort field")
             }
         , Input.checkbox []
             { onChange = \b -> UpdateSearch Ascending
             , icon = onOffSwitch
             , checked = model.ascending
-            , label = Input.labelLeft [] (E.text "Ascending:")
+            , label = Input.labelLeft [] (E.text "Ascending")
             }
         , Input.text []
             { onChange = \str -> UpdateSearch (Size str)
             , text = String.fromInt model.size
             , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Size:")
+            , label = Input.labelAbove [] (E.text "Size")
             }
         , Input.button
             [ Border.width 1

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -295,7 +295,7 @@ view : Model -> Html Msg
 view model =
     div []
         [ div [] [ viewSearchForms model ]
-        , div [] [ viewSearchResults model.searchStatus model.searchResults model.gmailUrl ]
+        , div [] [ E.layout [] <| viewSearchResults model.searchStatus model.searchResults model.gmailUrl ]
         ]
 
 
@@ -375,15 +375,15 @@ btn label msg =
     button [ onClick msg ] [ text label ]
 
 
-viewSearchResults : SearchStatus -> SearchResults -> String -> Html Msg
+viewSearchResults : SearchStatus -> SearchResults -> String -> E.Element Msg
 viewSearchResults status searchResults inboxUrl =
     let
         threadUrl =
             \id ->
                 inboxUrl ++ "#inbox/" ++ id
 
-        toc : List Message -> Html Msg
-        toc messages =
+        messageSummaries : List Message -> E.Element Msg
+        messageSummaries messages =
             let
                 messageRows : List (E.Element Msg)
                 messageRows =
@@ -417,31 +417,28 @@ viewSearchResults status searchResults inboxUrl =
                             E.column [] [ summary, expanded ]
                     in
                     List.map row messages
-
-                messagePane =
-                    E.column [] messageRows
             in
-            E.layout [] messagePane
+            E.column [] messageRows
     in
     case status of
         Loading ->
-            div [] [ text "Loading …" ]
+            E.el [] (E.text "Loading …")
 
         Success ->
             if List.length searchResults.messages > 0 then
-                div []
-                    [ div [] [ barGraph (timeSeries searchResults.chartData) ]
-                    , toc searchResults.messages
+                E.column []
+                    [ E.el [ E.width (E.px 800), E.height E.fill ] (E.html <| div [ id "graph" ] [ barGraph (timeSeries searchResults.chartData) ])
+                    , messageSummaries searchResults.messages
                     ]
 
             else
-                div [] []
+                E.el [] (E.text "No messages found")
 
         Failure e ->
-            div [] [ text <| "Search error:" ++ e ]
+            E.el [] <| E.text ("Search error:" ++ e)
 
         Empty ->
-            div [] []
+            E.none
 
 
 timeSeries : List ChartDay -> List ( Time.Posix, Float )

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -4,6 +4,7 @@ import BarGraph exposing (barGraph)
 import Browser
 import Debug
 import Element as E
+import Element.Font as Font
 import Html exposing (Html, a, br, button, div, h1, h2, input, label, li, p, table, tbody, td, text, textarea, th, thead, tr, ul)
 import Html.Attributes exposing (checked, class, cols, href, id, name, placeholder, rows, scope, type_, value)
 import Html.Events exposing (onClick, onInput)
@@ -367,23 +368,38 @@ viewSearchResults status searchResults inboxUrl =
                     , td [] [ text message.subject ]
                     ]
 
-        toc =
-            \messages ->
-                div []
-                    [ table []
-                        [ thead []
-                            [ tr []
-                                [ th [] [ text "Date" ]
-                                , th [] [ text "From" ]
-                                , th [] [ text "Gmail" ]
-                                , th [] [ text "Jump" ]
-                                , th [] [ text "Subject" ]
-                                ]
+        toc : List Message -> Html Msg
+        toc messages =
+            let
+                messagePane =
+                    E.table [ E.spacingXY 20 5 ]
+                        { data = messages
+                        , columns =
+                            [ { header = E.text "Date"
+                              , width = E.fill
+                              , view =
+                                    \message ->
+                                        E.text message.date
+                              }
+                            , { header = E.text "From"
+                              , width = E.px 300
+                              , view =
+                                    \message ->
+                                        E.paragraph [ E.clip ] [ E.text message.from ]
+                              }
+                            , { header = E.text "Message"
+                              , width = E.fill
+                              , view =
+                                    \message ->
+                                        E.row []
+                                            [ E.el [] <| E.text message.subject
+                                            , E.el [ Font.color <| E.rgba255 120 120 120 50 ] <| E.text <| " – " ++ message.snippet
+                                            ]
+                              }
                             ]
-                        , tbody []
-                            (List.map summaryRow messages)
-                        ]
-                    ]
+                        }
+            in
+            E.layout [] messagePane
 
         messagesView =
             \messages ->

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -333,67 +333,37 @@ onOffSwitch checked =
 
 viewSearchForm : SearchForm -> E.Element Msg
 viewSearchForm model =
+    let
+        searchField : (String -> SearchFormMsg) -> String -> String -> E.Element Msg
+        searchField msg val label =
+            Input.text []
+                { onChange = \str -> UpdateSearch (msg str)
+                , text = val
+                , placeholder = Nothing
+                , label = Input.labelAbove [] (E.text label)
+                }
+    in
     E.column [ E.spacing spacing ]
-        [ Input.text []
-            { onChange = \str -> UpdateSearch (Participants str)
-            , text = model.participants
-            , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Participants (applies to From, To, and CC)")
-            }
-        , Input.text []
-            { onChange = \str -> UpdateSearch (BodyOrSubject str)
-            , text = model.bodyOrSubject
-            , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Body or subject")
-            }
-        , Input.text []
-            { onChange = \str -> UpdateSearch (StartDate str)
-            , text = model.startDate
-            , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Start date (\"YYYY-MM-DD\")")
-            }
-        , Input.text []
-            { onChange = \str -> UpdateSearch (EndDate str)
-            , text = model.endDate
-            , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "End date (\"YYYY-MM-DD\")")
-            }
-        , Input.text []
-            { onChange = \str -> UpdateSearch (TimeZone str)
-            , text = model.timeZone
-            , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Time zone (e.g. -0800 for PST)")
-            }
-        , Input.text []
-            { onChange = \str -> UpdateSearch (Label str)
-            , text = model.label
-            , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Label")
-            }
+        [ searchField Participants model.participants "Participants (applies to From, To, and CC)"
+        , searchField BodyOrSubject model.bodyOrSubject "Body or subject"
+        , searchField StartDate model.startDate "Start date (\"YYYY-MM-DD\")"
+        , searchField EndDate model.endDate "End date (\"YYYY-MM-DD\")"
+        , searchField TimeZone model.timeZone "Time zone (e.g. -0800 for PST)"
+        , searchField Label model.label "Label"
         , Input.checkbox []
             { onChange = \b -> UpdateSearch StarredOnly
             , icon = onOffSwitch
             , checked = model.starredOnly
             , label = Input.labelLeft [] (E.text "Starred only")
             }
-        , Input.text []
-            { onChange = \str -> UpdateSearch (SortField str)
-            , text = model.sortField
-            , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Sort field")
-            }
+        , searchField SortField model.sortField "Sort field"
         , Input.checkbox []
             { onChange = \b -> UpdateSearch Ascending
             , icon = onOffSwitch
             , checked = model.ascending
             , label = Input.labelLeft [] (E.text "Ascending")
             }
-        , Input.text []
-            { onChange = \str -> UpdateSearch (Size str)
-            , text = String.fromInt model.size
-            , placeholder = Nothing
-            , label = Input.labelAbove [] (E.text "Size")
-            }
+        , searchField Size (String.fromInt model.size) "Size"
         , Input.button
             [ Border.width 1
             , Border.color <| E.rgb255 220 220 220

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -296,19 +296,19 @@ subscriptions model =
 
 view : Model -> Html Msg
 view model =
-    div []
-        [ div [] [ viewSearchForms model ]
-        , div [] [ E.layout [] <| viewSearchResults model.searchStatus model.searchResults model.gmailUrl ]
-        ]
+    E.layout [] <| E.column [] [ viewSearchForms model, viewSearchResults model.searchStatus model.searchResults model.gmailUrl ]
 
 
-viewSearchForms : Model -> Html Msg
+viewSearchForms : Model -> E.Element Msg
 viewSearchForms model =
-    div [ class "search-form" ]
-        [ formInput "gmailurl" "gmailurl" model.gmailUrl UpdateGmailUrl
-        , viewSearchForm model.searchForm
-        , div [] [ p [] [ text "OR" ] ]
-        , E.layout [] (viewRawSearchForm model.rawSearchForm)
+    E.column []
+        [ E.html <|
+            div [ class "search-form" ]
+                [ formInput "gmailurl" "gmailurl" model.gmailUrl UpdateGmailUrl
+                , viewSearchForm model.searchForm
+                , div [] [ p [] [ text "OR" ] ]
+                ]
+        , viewRawSearchForm model.rawSearchForm
         ]
 
 
@@ -339,13 +339,7 @@ viewRawSearchForm model =
     E.column
         []
         [ Input.multiline
-            [ E.height E.shrink
-            , Border.solid
-            , Border.width 5
-            , Border.rounded 30
-            , Border.color <| E.rgb255 200 200 200
-            , Background.color <| E.rgb255 200 30 30
-            ]
+            [ E.height E.shrink ]
             { onChange = \str -> UpdateRawSearch (Query str)
             , text = model.query
             , placeholder = Nothing
@@ -353,11 +347,15 @@ viewRawSearchForm model =
             , spellcheck = False
             }
         , Input.button
-            []
+            [ Border.width 1
+            , Border.color <| E.rgb255 220 220 220
+            , Border.rounded 5
+            , Font.size 12
+            , E.padding 3
+            ]
             { onPress = Just DoRawSearch
             , label = E.text "Raw query"
             }
-        , E.el [ Border.color <| E.rgb255 200 200 200 ] (E.text "hi")
         ]
 
 

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -4,8 +4,11 @@ import BarGraph exposing (barGraph)
 import Browser
 import Debug
 import Element as E
+import Element.Background as Background
+import Element.Border as Border
 import Element.Events as Ev
 import Element.Font as Font
+import Element.Input as Input
 import Html exposing (Html, a, br, button, div, h1, h2, input, label, li, p, table, tbody, td, text, textarea, th, thead, tr, ul)
 import Html.Attributes exposing (checked, class, cols, href, id, name, placeholder, rows, scope, type_, value)
 import Html.Events exposing (onClick, onInput)
@@ -305,7 +308,7 @@ viewSearchForms model =
         [ formInput "gmailurl" "gmailurl" model.gmailUrl UpdateGmailUrl
         , viewSearchForm model.searchForm
         , div [] [ p [] [ text "OR" ] ]
-        , viewRawSearchForm model.rawSearchForm
+        , E.layout [] (viewRawSearchForm model.rawSearchForm)
         ]
 
 
@@ -331,19 +334,30 @@ viewSearchForm model =
         ]
 
 
-viewRawSearchForm : RawSearchForm -> Html Msg
+viewRawSearchForm : RawSearchForm -> E.Element Msg
 viewRawSearchForm model =
-    let
-        rawSearchFormMessage : (String -> RawSearchFormMsg) -> (String -> Msg)
-        rawSearchFormMessage fn =
-            \str -> UpdateRawSearch (fn str)
-
-        queryField =
-            textarea [ rows 12, cols 120, name "query", value model.query, onInput (rawSearchFormMessage Query) ] []
-    in
-    div []
-        [ formField "Query:" queryField
-        , btn "raw query" DoRawSearch
+    E.column
+        []
+        [ Input.multiline
+            [ E.height E.shrink
+            , Border.solid
+            , Border.width 5
+            , Border.rounded 30
+            , Border.color <| E.rgb255 200 200 200
+            , Background.color <| E.rgb255 200 30 30
+            ]
+            { onChange = \str -> UpdateRawSearch (Query str)
+            , text = model.query
+            , placeholder = Nothing
+            , label = Input.labelAbove [] (E.text "Query")
+            , spellcheck = False
+            }
+        , Input.button
+            []
+            { onPress = Just DoRawSearch
+            , label = E.text "Raw query"
+            }
+        , E.el [ Border.color <| E.rgb255 200 200 200 ] (E.text "hi")
         ]
 
 


### PR DESCRIPTION
Adds the ability to expand message summaries. Just click on a message summary to see the full message (also shows a link to Gmail).

Also adds a loading status (which we can change to a spinner later). FYI, [example spinner in Ellie](https://ellie-app.com/4KZJzy7LVCpa1). This is just the provided example in an Ellie sandbox.

Note: Uses [elm-ui](https://package.elm-lang.org/packages/mdgriffith/elm-ui/latest/). The author's [Elm Conf 2018 presentation](https://www.youtube.com/watch?v=Ie-gqwSHQr0) has more info.

Question:
- This iterates through the list of messages to toggle expanded state, but the code would be simpler if we had the messages be a `Dict` instead of a `List`. Do we want to change the API to have messages be a json object keyed with message ids?


Resolves #63 