### PR TITLE
WIP: create top bar visual element

### DIFF
--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -3,7 +3,10 @@ module Main exposing (ChartDay, Message, Model, Msg(..), RawSearchForm, RawSearc
 import BarGraph exposing (barGraph)
 import Browser
 import Debug
-import Element as E
+import Element as E exposing (Element, el, fill, row, column,
+                              width, height, padding, rgb255)
+import Element.Background as Background
+import Element.Border as Border
 import Element.Events as Ev
 import Element.Font as Font
 import Html exposing (Html, a, br, button, div, h1, h2, input, label, li, p, table, tbody, td, text, textarea, th, thead, tr, ul)
@@ -293,11 +296,25 @@ subscriptions model =
 
 view : Model -> Html Msg
 view model =
-    div []
-        [ div [] [ viewSearchForms model ]
-        , div [] [ E.layout [] <| viewSearchResults model.searchStatus model.searchResults model.gmailUrl ]
-        ]
+    E.layout [] <|
+        column []
+            [ viewTopbar
+            , E.html <| viewSearchForms model
+            , viewSearchResults model.searchStatus model.searchResults model.gmailUrl
+            ]
 
+appTitle : Element msg
+appTitle =
+    el
+        [ Font.color (rgb255 255 255 255)
+        , padding 20
+        ]
+        (E.text "Calliope")
+
+viewTopbar : Element msg
+viewTopbar =
+    row [width fill, Background.color <| rgb255 92 99 118]
+        [ appTitle ]
 
 viewSearchForms : Model -> Html Msg
 viewSearchForms model =

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -297,7 +297,7 @@ subscriptions model =
 view : Model -> Html Msg
 view model =
     E.layout [] <|
-        column []
+        column [width fill]
             [ viewTopbar
             , E.html <| viewSearchForms model
             , viewSearchResults model.searchStatus model.searchResults model.gmailUrl


### PR DESCRIPTION
this is a simple visual element at the top of the screen in elm-ui
for some reason it doesn't stretch to the full width of the page

I'll rebase after you merge to master, just wanted to ask you about the stretchiness.  
Here's what it looks like for me (notice large white gap before the inspector):

![image](https://user-images.githubusercontent.com/41906/52981265-5f160b00-3393-11e9-8d80-ad65fc103ad1.png)
