### PR TITLE
Reports in Elm app

### DIFF
--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -296,7 +296,22 @@ update msg model =
                             let
                                 wrapMessage : Message -> MessageWrapper
                                 wrapMessage message =
-                                    ( message, Nothing )
+                                    let
+                                        parsed =
+                                            Html.Parser.run message.bodyHtml
+
+                                        h =
+                                            case parsed of
+                                                Ok p ->
+                                                    Html.Parser.Util.toVirtualDom p
+                                                        |> Html.div []
+                                                        |> html
+                                                        |> Just
+
+                                                Err e ->
+                                                    Nothing
+                                    in
+                                    ( message, h )
                             in
                             List.map wrapMessage messages
 


### PR DESCRIPTION
Only commit currently is an experiment to see how long it would take to parse all emails. Answer is 17s on 2016 MBP, so we will need some UI feedback for user. Current thought is to parse an email at a time, updating the UI after each email is parsed, and showing spinners for remaining emails.