### PR TITLE
Using Browser.application instead of Browser.element 

### DIFF
--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -105,7 +105,6 @@ type alias Model =
     , searchResults : SearchResults
     , expandedMessageId : String
     , searchStatus : SearchStatus
-    , showAdvancedSearch : Bool
     , windowWidth : Int
     }
 
@@ -180,6 +179,13 @@ init width url key =
 
         emptySearchResults =
             SearchResults "" [] []
+
+        cmd =
+            if url.path == "/" then
+                Navigation.pushUrl key "/search"
+
+            else
+                Cmd.none
     in
     ( { key = key
       , model =
@@ -190,11 +196,10 @@ init width url key =
             , searchResults = emptySearchResults
             , expandedMessageId = ""
             , searchStatus = Empty
-            , showAdvancedSearch = False
             , windowWidth = width
             }
       }
-    , Cmd.none
+    , cmd
     )
 
 
@@ -248,6 +253,20 @@ updateWithKey msg modelWithKey =
                     , Navigation.load url
                     )
 
+        ToggleAdvancedSearch ->
+            let
+                model =
+                    modelWithKey.model
+
+                cmd =
+                    if model.url.path == "/search" then
+                        Navigation.pushUrl modelWithKey.key "/advanced-search"
+
+                    else
+                        Navigation.pushUrl modelWithKey.key "/search"
+            in
+            ( modelWithKey, cmd )
+
         _ ->
             let
                 ( newModel, newMsg ) =
@@ -260,6 +279,10 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         UrlChangeRequested _ ->
+            -- Should never happen
+            ( model, Cmd.none )
+
+        ToggleAdvancedSearch ->
             -- Should never happen
             ( model, Cmd.none )
 
@@ -282,9 +305,6 @@ update msg model =
               }
             , Cmd.none
             )
-
-        ToggleAdvancedSearch ->
-            ( { model | showAdvancedSearch = not model.showAdvancedSearch }, Cmd.none )
 
         Toggle id ->
             if id == model.expandedMessageId then
@@ -530,7 +550,7 @@ viewSearchForms : Model -> Element Msg
 viewSearchForms model =
     let
         searchForm =
-            if model.showAdvancedSearch then
+            if model.url.path == "/advanced-search" then
                 viewRawSearchForm model.rawSearchForm
 
             else

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -316,21 +316,15 @@ update msg model =
 
                                 Nothing ->
                                     let
-                                        maybeHtml =
+                                        messageBody =
                                             Html.Parser.run message.bodyHtml
-
-                                        style =
-                                            Attributes.style
-
-                                        scrollAttrs =
-                                            [ clip, Element.scrollbars, Element.height <| px graphHeight ]
+                                                |> Result.toMaybe
+                                                |> Maybe.andThen (\parsed -> Just (Html.div [] (Html.Parser.Util.toVirtualDom parsed)))
+                                                |> Maybe.withDefault (Html.text "Error parsing html")
+                                                |> html
+                                                |> el [ clip, Element.scrollbars, Element.height <| px graphHeight ]
                                     in
-                                    case maybeHtml of
-                                        Ok parsed ->
-                                            ( message, Just <| el scrollAttrs (html <| Html.div [] (Html.Parser.Util.toVirtualDom parsed)) )
-
-                                        Err _ ->
-                                            ( message, Just <| el [] (text "Error parsing html") )
+                                    ( message, Just messageBody )
                 in
                 ( { model | searchResults = searchResults, expandedMessageId = id }, Cmd.none )
 

--- a/client/calliope/src/Main.elm
+++ b/client/calliope/src/Main.elm
@@ -156,6 +156,10 @@ type alias SearchResults =
     }
 
 
+emptySearchResults =
+    SearchResults "" [] []
+
+
 init : Int -> Url.Url -> Navigation.Key -> ( ModelWithKey, Cmd Msg )
 init width url key =
     let
@@ -176,9 +180,6 @@ init width url key =
     }
   ]
 }"""
-
-        emptySearchResults =
-            SearchResults "" [] []
 
         cmd =
             if url.path == "/" then
@@ -291,7 +292,7 @@ updateWithKey msg modelWithKey =
                     else
                         Navigation.pushUrl modelWithKey.key "/search"
             in
-            ( modelWithKey, cmd )
+            ( { modelWithKey | model = { model | searchResults = emptySearchResults } }, cmd )
 
         DoSearch ->
             ( { modelWithKey | model = { model | searchStatus = Loading } }, doSearch model.searchForm key )
@@ -596,7 +597,7 @@ viewSearchForms model =
         ]
         [ el [ width fill ] <|
             Input.text inputTextStyle
-                { onChange = \str -> UpdateGmailUrl str
+                { onChange = UpdateGmailUrl
                 , text = model.gmailUrl
                 , placeholder = Nothing
                 , label = Input.labelAbove [] (text "Gmail url (useful if you are signed in to multiple Gmail accounts simultaneously)")
@@ -623,7 +624,7 @@ viewSearchForm model =
         searchField : (String -> SearchFormMsg) -> String -> String -> Element Msg
         searchField msg val label =
             Input.text inputTextStyle
-                { onChange = \str -> UpdateSearch (msg str)
+                { onChange = UpdateSearch << msg
                 , text = val
                 , placeholder = Nothing
                 , label = Input.labelAbove [] (text label)
@@ -645,13 +646,13 @@ viewSearchForm model =
                 [ searchField BodyOrSubject model.bodyOrSubject "Body or subject"
                 , row [ width fill ]
                     [ Input.text (width (fillPortion 4) :: inputTextStyle)
-                        { onChange = \str -> UpdateSearch (Label str)
+                        { onChange = UpdateSearch << Label
                         , text = model.label
                         , placeholder = Nothing
                         , label = Input.labelAbove [] (text "Label")
                         }
                     , Input.checkbox [ width (fillPortion 1), gutter ]
-                        { onChange = \b -> UpdateSearch StarredOnly
+                        { onChange = \_ -> UpdateSearch StarredOnly
                         , icon = onOffSwitch
                         , checked = model.starredOnly
                         , label = Input.labelLeft [] (text "Starred only")
@@ -659,13 +660,13 @@ viewSearchForm model =
                     ]
                 , row [ width fill ]
                     [ Input.text (width (fillPortion 4) :: inputTextStyle)
-                        { onChange = \str -> UpdateSearch (SortField str)
+                        { onChange = UpdateSearch << SortField
                         , text = model.sortField
                         , placeholder = Nothing
                         , label = Input.labelAbove [] (text "Sort field")
                         }
                     , Input.checkbox [ width (fillPortion 1), gutter ]
-                        { onChange = \b -> UpdateSearch Ascending
+                        { onChange = \_ -> UpdateSearch Ascending
                         , icon = onOffSwitch
                         , checked = model.ascending
                         , label = Input.labelLeft [] (text "Ascending")
@@ -722,9 +723,6 @@ viewRawSearchForm model =
 viewSearchResults : Model -> Element Msg
 viewSearchResults model =
     let
-        windowWidth =
-            model.windowWidth
-
         status =
             model.searchStatus
 

--- a/client/calliope/src/main.css
+++ b/client/calliope/src/main.css
@@ -1,4 +1,4 @@
-/*
+  /*
   elm-hot creates an additional div wrapper around the app to make HMR possible.
   This could break styling in development mode if you are using Elm UI.
 

--- a/client/calliope/tests/TestMain.elm
+++ b/client/calliope/tests/TestMain.elm
@@ -194,16 +194,24 @@ url =
     }
 
 
+fakeNav : Nav
+fakeNav =
+    { pushUrl = \str -> Cmd.none
+    , replaceUrl = \str -> Cmd.none
+    , back = \i -> Cmd.none
+    }
+
+
 defaultModel : Model
 defaultModel =
     { url = url
+    , nav = fakeNav
     , gmailUrl = "https://mail.google.com/mail/"
     , searchForm = SearchForm "" "" "" "" "" "" False "Date" False 100
     , rawSearchForm = RawSearchForm ""
     , searchResults = searchResults
     , expandedMessageId = ""
     , searchStatus = Empty
-    , showAdvancedSearch = False
     , windowWidth = 800
     }
 

--- a/client/calliope/tests/TestMain.elm
+++ b/client/calliope/tests/TestMain.elm
@@ -76,6 +76,40 @@ searchResultsDecoderTest =
         ]
 
 
+routesTest : Test
+routesTest =
+    describe "routes"
+        [ describe "when starting with a valid search url"
+            [ describe "to /search"
+                [ todo "it populates the search form"
+                , todo "it runs a search"
+                ]
+            , describe "to /advanced-search"
+                [ todo "it populates the search form"
+                , todo "it runs a search"
+                ]
+            ]
+        , describe "toggling to /advanced-search from /search"
+            [ describe "without search results"
+                [ todo "show form with default query"
+                , todo "url should be /advanced-search no query"
+                , todo "search results should be unchanged"
+                ]
+            , describe "with search results run by basic search"
+                [ todo "show form with query field filled in with the last run query"
+                , todo "url should be /advanced-search?query=<query> where <query> is the last run query"
+                , todo "search results should be unchanged"
+                ]
+            ]
+        , describe "toggling to /search from /advanced-search"
+            [ describe "without search results" []
+            , describe "with search results from an advanced-search"
+                [ todo "we need to figure out whether something should happen – the search form won't match"
+                ]
+            ]
+        ]
+
+
 updateTest : Test
 updateTest =
     describe "update"

--- a/client/calliope/tests/TestMain.elm
+++ b/client/calliope/tests/TestMain.elm
@@ -150,9 +150,20 @@ searchResults =
     { emptySearchResults | messagesWithHtml = threeWrappedMessages }
 
 
+url =
+    { protocol = Http
+    , host = "localhost"
+    , port_ = Just 3000
+    , path = "/"
+    , query = Nothing
+    , fragment = Nothing
+    }
+
+
 defaultModel : Model
 defaultModel =
-    { gmailUrl = "https://mail.google.com/mail/"
+    { url = url
+    , gmailUrl = "https://mail.google.com/mail/"
     , searchForm = SearchForm "" "" "" "" "" "" False "Date" False 100
     , rawSearchForm = RawSearchForm ""
     , searchResults = searchResults

--- a/client/calliope/tests/TestMain.elm
+++ b/client/calliope/tests/TestMain.elm
@@ -92,22 +92,22 @@ toggleIdTests =
             [ test "the target should be listed as expanded" <|
                 \_ ->
                     Expect.equal "2" updated.expandedMessageId
-            , test "the target should have parsed html" <|
+            , test "the target should have a message body" <|
                 \_ ->
                     let
-                        expanded =
+                        idsWithMessageBodies =
                             let
                                 appendIfParsed : MessageWrapper -> List String -> List String
-                                appendIfParsed ( message, parsed ) parsedList =
-                                    if parsed /= Nothing then
-                                        message.id :: parsedList
+                                appendIfParsed ( message, parsedHtml ) ids =
+                                    if parsedHtml /= Nothing then
+                                        message.id :: ids
 
                                     else
-                                        parsedList
+                                        ids
                             in
                             List.foldl appendIfParsed [] updated.searchResults.messagesWithHtml
                     in
-                    Expect.equalLists [ "2" ] expanded
+                    Expect.equalLists [ "2" ] idsWithMessageBodies
             ]
         , describe "when target is already expanded" <|
             let


### PR DESCRIPTION
Using `Browser.application` so we can respond to URL changes.

To do:
- [x] Separate routes for `/search` and `/advanced-search`
- [x] Redirect `/` to `/search`
- [x] When searching, url is updated to include the search parameters
- [x] When opening the app w/ a saved URL, the forms show the search criteria and the search is run
- [x] Back button support (should be tested more though)
- [x] Create a wrapper for Browser.Navigator that doesn't require key
